### PR TITLE
Allow tests to be run locally easier

### DIFF
--- a/acceptance/acceptance_suite_test.go
+++ b/acceptance/acceptance_suite_test.go
@@ -44,9 +44,12 @@ var _ = BeforeSuite(func() {
 	mustHaveBoshEnvVars()
 	ensureBBR()
 
-	config := NewConfig(mustHaveEnv("CONFIG_PATH"))
-	filter = NewTestCaseFilter(mustHaveEnv("CONFIG_PATH"))
-	testCases = filter.Filter(availableTestCases)
+	testCases = availableTestCases
+	config := NewConfig(os.Getenv("CONFIG_PATH"))
+	filter = NewTestCaseFilter(os.Getenv("CONFIG_PATH"))
+	if filter != nil {
+		testCases = filter.Filter(availableTestCases)
+	}
 
 	fmt.Println("Running test cases:")
 	for _, t := range testCases {
@@ -57,17 +60,11 @@ var _ = BeforeSuite(func() {
 	SetDefaultEventuallyTimeout(time.Minute * config.TimeoutMinutes)
 	SetDefaultEventuallyPollingInterval(time.Second * 5)
 	fmt.Printf("Timeout: %d min\n\n", config.TimeoutMinutes)
-
 	artifactPath = createTempDir()
-	kubeCACertPath = writeTempFile(config.CACert)
-	configureKubectl(config.APIServerURL, config.Username, config.Password, kubeCACertPath)
 })
 
 var _ = AfterSuite(func() {
-	err := os.RemoveAll(kubeCACertPath)
-	Expect(err).NotTo(HaveOccurred())
-
-	err = os.RemoveAll(artifactPath)
+	err := os.RemoveAll(artifactPath)
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/acceptance/config.go
+++ b/acceptance/config.go
@@ -3,6 +3,7 @@ package acceptance
 import (
 	"encoding/json"
 	"io/ioutil"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -17,16 +18,17 @@ type Config struct {
 }
 
 func NewConfig(path string) Config {
-	rawConfig, err := ioutil.ReadFile(path)
+	config := Config{
+		TimeoutMinutes: 5,
+	}
+	if path == "" {
+		return config
+	}
+	rawConfig, err := ioutil.ReadFile(filepath.Clean(path))
 	Expect(err).NotTo(HaveOccurred())
 
-	var config Config
 	err = json.Unmarshal(rawConfig, &config)
 	Expect(err).NotTo(HaveOccurred())
-
-	if config.TimeoutMinutes == 0 {
-		config.TimeoutMinutes = 5
-	}
 
 	return config
 }

--- a/acceptance/filter.go
+++ b/acceptance/filter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	. "github.com/onsi/gomega"
 )
@@ -11,7 +12,10 @@ import (
 type TestCaseFilter map[string]interface{}
 
 func NewTestCaseFilter(path string) TestCaseFilter {
-	rawConfig, err := ioutil.ReadFile(path)
+	if path == "" {
+		return nil
+	}
+	rawConfig, err := ioutil.ReadFile(filepath.Clean(path))
 	Expect(err).NotTo(HaveOccurred())
 
 	filter := TestCaseFilter{}


### PR DESCRIPTION
Hopefully this can help fix #2.

PKS are also currently using this branch

* Add defaults if no config is provided
  * Run all tests
  * Use 5minutes default timeout
* Use kubeconfig that is on system

