### PR TITLE
Added concepts of Pod Security Policy, Service Account, and Role to k-drats

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Kubo", func() {
 
 				Expect(deployments.Items).To(HaveLen(1), fmt.Sprintf("one %s deployment should exist, instead found: %#v", selector, deployments.Items))
 
-				err = k8sClient.WaitForDeployment("kube-system", deployments.Items[0].Name, time.Minute*4, GinkgoWriter)
+				err = k8sClient.WaitForDeployment("kube-system", deployments.Items[0].Name, time.Minute*5, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Kubo", func() {
 
 				Expect(deployments.Items).To(HaveLen(1), fmt.Sprintf("one %s deployment should exist, instead found: %#v", selector, deployments.Items))
 
-				err = k8sClient.WaitForDeployment("kube-system", deployments.Items[0].Name, time.Minute*1, GinkgoWriter)
+				err = k8sClient.WaitForDeployment("kube-system", deployments.Items[0].Name, time.Minute*4, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		})

--- a/kubernetes/deployment.go
+++ b/kubernetes/deployment.go
@@ -13,8 +13,9 @@ func NewDeployment(name string, spec appsv1.DeploymentSpec) *appsv1.Deployment {
 	}
 }
 
-func NewNginxDeploymentSpec() appsv1.DeploymentSpec {
+func NewNginxDeploymentSpec(serviceAccountName string) appsv1.DeploymentSpec {
 	nginxPodSpec := corev1.PodSpec{
+		ServiceAccountName: serviceAccountName,
 		Containers: []corev1.Container{{
 			Name:  "nginx",
 			Image: "nginx",

--- a/kubernetes/psp.go
+++ b/kubernetes/psp.go
@@ -1,0 +1,63 @@
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewPodSecurityPolicy(name string, spec policyv1.PodSecurityPolicySpec) *policyv1.PodSecurityPolicy {
+	return &policyv1.PodSecurityPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Annotations: map[string]string{
+				"seccomp.security.alpha.kubernetes.io/allowedProfileNames": "docker/default",
+				"apparmor.security.beta.kubernetes.io/allowedProfileNames": "runtime/default",
+				"seccomp.security.alpha.kubernetes.io/defaultProfileName":  "docker/default",
+				"apparmor.security.beta.kubernetes.io/defaultProfileName":  "runtime/default",
+			},
+		},
+		Spec: spec,
+	}
+}
+
+func NewPodSecurityPolicySpec() policyv1.PodSecurityPolicySpec {
+	var allowPrivilegedEscalation bool
+	allowPrivilegedEscalation = false
+	labelMap := make(map[string]string)
+	labelMap["app"] = "nginx"
+
+	return policyv1.PodSecurityPolicySpec{
+		Privileged:               false,
+		AllowPrivilegeEscalation: &allowPrivilegedEscalation,
+		AllowedCapabilities:      []corev1.Capability{"*"},
+		HostNetwork:              true,
+		HostPorts: []policyv1.HostPortRange{
+			{
+				Min: 0,
+				Max: 65535,
+			},
+		},
+		HostIPC: true,
+		HostPID: true,
+		Volumes: []policyv1.FSType{
+			"configMap",
+			"emptyDir",
+			"projected",
+			"secret",
+			"downwardAPI",
+		},
+		RunAsUser: policyv1.RunAsUserStrategyOptions{
+			Rule: policyv1.RunAsUserStrategyRunAsAny,
+		},
+		SELinux: policyv1.SELinuxStrategyOptions{
+			Rule: policyv1.SELinuxStrategyRunAsAny,
+		},
+		SupplementalGroups: policyv1.SupplementalGroupsStrategyOptions{
+			Rule: policyv1.SupplementalGroupsStrategyRunAsAny,
+		},
+		FSGroup: policyv1.FSGroupStrategyOptions{
+			Rule: policyv1.FSGroupStrategyRunAsAny,
+		},
+	}
+}

--- a/kubernetes/role.go
+++ b/kubernetes/role.go
@@ -1,0 +1,37 @@
+package kubernetes
+
+import (
+	rbac "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewRole(name, pspResourceName string) *rbac.Role {
+	return &rbac.Role{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Rules: []rbac.PolicyRule{
+			{
+				APIGroups:     []string{"extensions"},
+				ResourceNames: []string{pspResourceName},
+				Resources:     []string{"podsecuritypolicies"},
+				Verbs:         []string{"use"},
+			},
+		},
+	}
+}
+
+func NewRoleBinding(roleName, roleBindingName, serviceAccountName string) *rbac.RoleBinding {
+	return &rbac.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: roleBindingName},
+		RoleRef: rbac.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     roleName,
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind: "ServiceAccount",
+				Name: serviceAccountName,
+			},
+		},
+	}
+}

--- a/kubernetes/service_account.go
+++ b/kubernetes/service_account.go
@@ -1,0 +1,12 @@
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewServiceAccount(name string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}

--- a/testcase/deployment.go
+++ b/testcase/deployment.go
@@ -12,12 +12,16 @@ import (
 )
 
 type Deployment struct {
-	k8sClient        *kubernetes.Client
-	namespace        string
-	nginx1Deployment *v1.Deployment
-	nginx2Deployment *v1.Deployment
-	nginx3Deployment *v1.Deployment
-	timeout          time.Duration
+	k8sClient             *kubernetes.Client
+	namespace             string
+	nginx1Deployment      *v1.Deployment
+	nginx2Deployment      *v1.Deployment
+	nginx3Deployment      *v1.Deployment
+	timeout               time.Duration
+	serviceAccountName    string
+	podSecurityPolicyName string
+	roleName              string
+	roleBindingName       string
 }
 
 func NewDeployment() *Deployment {
@@ -41,13 +45,31 @@ func (t *Deployment) BeforeBackup(config Config) {
 		t.timeout = 5 * time.Minute
 	})
 
+	By("Creating a service account with PSP privileges", func() {
+		t.serviceAccountName = "deployment"
+		_, err := t.k8sClient.CreateServiceAccount(t.namespace, kubernetes.NewServiceAccount(t.serviceAccountName))
+		Expect(err).ToNot(HaveOccurred())
+
+		t.podSecurityPolicyName = "deployment-psp"
+		_, err = t.k8sClient.CreatePodSecurityPolicy(kubernetes.NewPodSecurityPolicy(t.podSecurityPolicyName, kubernetes.NewPodSecurityPolicySpec()))
+		Expect(err).ToNot(HaveOccurred())
+
+		t.roleName = "deployment-role"
+		_, err = t.k8sClient.CreateRole(t.namespace, kubernetes.NewRole(t.roleName, t.podSecurityPolicyName))
+		Expect(err).ToNot(HaveOccurred())
+
+		t.roleBindingName = "deployment-role-binding"
+		_, err = t.k8sClient.CreateRoleBinding(t.namespace, kubernetes.NewRoleBinding(t.roleName, t.roleBindingName, t.serviceAccountName))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 	By("Deploying workload 1 and 2", func() {
 		var err error
-		t.nginx1Deployment = kubernetes.NewDeployment("nginx-1", kubernetes.NewNginxDeploymentSpec())
+		t.nginx1Deployment = kubernetes.NewDeployment("nginx-1", kubernetes.NewNginxDeploymentSpec(t.serviceAccountName))
 		t.nginx1Deployment, err = t.k8sClient.CreateDeployment(t.namespace, t.nginx1Deployment)
 		Expect(err).ToNot(HaveOccurred())
 
-		t.nginx2Deployment = kubernetes.NewDeployment("nginx-2", kubernetes.NewNginxDeploymentSpec())
+		t.nginx2Deployment = kubernetes.NewDeployment("nginx-2", kubernetes.NewNginxDeploymentSpec(t.serviceAccountName))
 		t.nginx2Deployment, err = t.k8sClient.CreateDeployment(t.namespace, t.nginx2Deployment)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -67,7 +89,7 @@ func (t *Deployment) AfterBackup(config Config) {
 
 	By("Deploying workload 3", func() {
 		var err error
-		t.nginx3Deployment = kubernetes.NewDeployment("nginx-3", kubernetes.NewNginxDeploymentSpec())
+		t.nginx3Deployment = kubernetes.NewDeployment("nginx-3", kubernetes.NewNginxDeploymentSpec(t.serviceAccountName))
 		t.nginx3Deployment, err = t.k8sClient.CreateDeployment(t.namespace, t.nginx3Deployment)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -98,6 +120,11 @@ func (t *Deployment) AfterRestore(config Config) {
 func (t *Deployment) Cleanup(config Config) {
 	By("Deleting the test namespace", func() {
 		err := t.k8sClient.DeleteNamespace(t.namespace)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	By("Deleting the pod security policy", func() {
+		err := t.k8sClient.DeletePodSecurityPolicy(t.podSecurityPolicyName)
 		Expect(err).NotTo(HaveOccurred())
 	})
 }

--- a/testcase/deployment.go
+++ b/testcase/deployment.go
@@ -42,7 +42,7 @@ func (t *Deployment) BeforeBackup(config Config) {
 		Expect(err).ToNot(HaveOccurred())
 		t.namespace = nsObject.Name
 
-		t.timeout = 5 * time.Minute
+		t.timeout = 10 * time.Minute
 	})
 
 	By("Creating a service account with PSP privileges", func() {


### PR DESCRIPTION
Start iterating on adding pod security polices to k-drats and creating a role with it and binding it to a service key which we use to create our deployments.

The test cases affected are:
- pod health
- deployment
[#165528609]

Signed-off-by: Glen Rodgers <grodgers@pivotal.io>