### PR TITLE
Changes logging message for wait loop

### DIFF
--- a/kubernetes/client.go
+++ b/kubernetes/client.go
@@ -84,7 +84,7 @@ func (c *Client) WaitForDeployment(namespace, deploymentName string, timeout tim
 			if deployment.Status.AvailableReplicas == deployment.Status.UpdatedReplicas {
 				return true, nil
 			}
-			fmt.Fprintf(writer, "Expected %d to be equal to %d\n", deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
+			fmt.Fprintf(writer, "Waiting for %d to be equal to %d\n", deployment.Status.AvailableReplicas, deployment.Status.UpdatedReplicas)
 		}
 
 		return false, nil


### PR DESCRIPTION
The former wait loop logging made it look
like a test failure since it used "Expected"
However, it is just polling for desired outcome

Co-authored-by: Todd Sedano <tsedano@pivotal.io>
Co-authored-by: Larry Hamel <lhamel@pivotal.io>