### PR TITLE
Increase k8s client timeout to avoid task run-k-drats failure of raas…

### DIFF
--- a/testcase/deployment.go
+++ b/testcase/deployment.go
@@ -42,7 +42,7 @@ func (t *Deployment) BeforeBackup(config Config) {
 		Expect(err).ToNot(HaveOccurred())
 		t.namespace = nsObject.Name
 
-		t.timeout = 10 * time.Minute
+		t.timeout = 20 * time.Minute
 	})
 
 	By("Creating a service account with PSP privileges", func() {


### PR DESCRIPTION
… pipeline